### PR TITLE
Some minor contributions to radioapi

### DIFF
--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -118,7 +118,7 @@
 					}
 
 					// Get Satellite Mode
-					$uplink_mode = $this->get_mode_designator($row->uplink_freq);
+					$uplink_mode = $this->get_mode_designator($row->frequency);
 					$downlink_mode = $this->get_mode_designator($row->downlink_freq);
 
 					if (empty($uplink_mode)) {

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -43,7 +43,7 @@
 			} else if (isset($result['downlink_freq'])) {
 				$data['downlink_freq'] = $result['downlink_freq'];
 			} else {
-				$data['downlink_freq'] = 0;
+				$data['downlink_freq'] = NULL;
 			}
 			if (isset($result['mode_rx'])) {
 				$data['downlink_mode'] = $result['mode_rx'];

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -28,14 +28,22 @@
 			// Let's keep uplink_freq, downlink_freq, uplink_mode and downlink_mode for backward compatibility
 			$data = array(
 				'prop_mode' => $prop_mode,
-				'frequency' => $result['frequency'] ?? $result['uplink_freq'],
 				'downlink_freq' => $result['frequency_rx'] ?? $result['downlink_freq'],
-				'mode' => $result['mode'] ?? $result['uplink_mode'],
 				'downlink_mode' => $result['mode_rx'] ?? $result['downlink_mode'],
 				'power' => $result['power'],
 				'sat_name' => $result['sat_name'],
 				'timestamp' => $timestamp,
 			);
+			if (isset($result['frequency']) && $result['frequency'] != "NULL") {
+				$data['frequency'] = $result['frequency'];
+			} else {
+				$data['frequency'] = $result['uplink_freq'];
+			}
+			if (isset($result['mode']) && $result['mode'] != "NULL") {
+				$data['mode'] = $result['mode'];
+			} else {
+				$data['mode'] = $result['uplink_mode'];
+			}
 
 			if ($query->num_rows() > 0)
 			{

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -4,11 +4,7 @@
 
 		function update($result, $user_id) {
 
-			if ($result['timestamp'] != "") {
-				$timestamp = gmdate("Y-m-d H:i:s");
-			} else {
-				$timestamp = gmdate("Y-m-d H:i:s");
-			}
+			$timestamp = gmdate("Y-m-d H:i:s");
 
 			if (isset($result['prop_mode'])) {
 				$prop_mode = $result['prop_mode'];

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -24,10 +24,8 @@
 			// Let's keep uplink_freq, downlink_freq, uplink_mode and downlink_mode for backward compatibility
 			$data = array(
 				'prop_mode' => $prop_mode,
-				'downlink_freq' => $result['frequency_rx'] ?? $result['downlink_freq'],
-				'downlink_mode' => $result['mode_rx'] ?? $result['downlink_mode'],
-				'power' => $result['power'],
-				'sat_name' => $result['sat_name'],
+				'power' => $result['power'] ?? 0,
+				'sat_name' => $result['sat_name'] ?? NULL,
 				'timestamp' => $timestamp,
 			);
 			if (isset($result['frequency']) && $result['frequency'] != "NULL") {
@@ -39,6 +37,20 @@
 				$data['mode'] = $result['mode'];
 			} else {
 				$data['mode'] = $result['uplink_mode'];
+			}
+			if (isset($result['frequency_rx'])) {
+				$data['downlink_freq'] = $result['frequency_rx'];
+			} else if (isset($result['downlink_freq'])) {
+				$data['downlink_freq'] = $result['downlink_freq'];
+			} else {
+				$data['downlink_freq'] = 0;
+			}
+			if (isset($result['mode_rx'])) {
+				$data['downlink_mode'] = $result['mode_rx'];
+			} else if (isset($result['downlink_freq'])) {
+				$data['downlink_mode'] = $result['downlink_mode'];
+			} else {
+				$data['downlink_mode'] = NULL;
 			}
 
 			if ($query->num_rows() > 0)


### PR DESCRIPTION
With 5bfcabb2232302cedb0f64dad822b5d089a6061b I removed the useless if else. Not sure why that was there at all. We would set the timestamp within Cloudlog even if the CAT software supplies a timestamp (as noted per https://github.com/magicbug/Cloudlog/pull/1582#issuecomment-1261417464).

Commit 0b57df36cf4182c6833752e0b2da2b98bdfa9d57 adds a check if frequency and mode are "NULL" (i.e. string not NULL as no value at all because CloudLogCatQt sends `"frequency" : "NULL" ,"mode" : "NULL"` when in SAT mode:

![Screenshot from 2022-09-29 12-40-10](https://user-images.githubusercontent.com/7112907/193017632-2477c1ae-7636-4375-af0a-a545d5cce7ae.png)

And this leads to mode being NULL and frequency being 0 in Cloudlog:

![Screenshot from 2022-09-29 12-39-58](https://user-images.githubusercontent.com/7112907/193017714-63cf4d46-3512-49a1-94f4-c1db57f0e169.png)

So with this additional check mode and frequency are only used if they are set and do not contain "NULL":

