### PR TITLE
Drop redundant columns

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -21,7 +21,7 @@ $config['migration_enabled'] = TRUE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 99;
+$config['migration_version'] = 100;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -118,7 +118,7 @@
 					}
 
 					// Get Satellite Mode
-					$uplink_mode = $this->get_mode_designator($row->uplink_freq);
+					$uplink_mode = $this->get_mode_designator($row->frequency);
 					$downlink_mode = $this->get_mode_designator($row->downlink_freq);
 
 					if (empty($uplink_mode)) {

--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -51,18 +51,18 @@
 
 				if (empty($row->frequency) || $row->frequency == "0") {
 					echo "<td>- / -</td>";
-				} elseif (empty($row->downlink_freq) || $row->downlink_freq == "0") {
+				} elseif (empty($row->frequency_rx) || $row->frequency_rx == "0") {
 					echo "<td>".$this->frequency->hz_to_mhz($row->frequency)."</td>";
 				} else {
-					echo "<td>".$this->frequency->hz_to_mhz($row->downlink_freq)." / ".$this->frequency->hz_to_mhz($row->frequency)."</td>";
+					echo "<td>".$this->frequency->hz_to_mhz($row->frequency_rx)." / ".$this->frequency->hz_to_mhz($row->frequency)."</td>";
 				}
 
 				if (empty($row->mode) || $row->mode == "non") {
 					echo "<td>N/A</td>";
-				} elseif (empty($row->downlink_mode) || $row->downlink_mode == "non") {
+				} elseif (empty($row->mode_rx) || $row->mode_rx == "non") {
 					echo "<td>".$row->mode."</td>";
 				} else {
-					echo "<td>".$row->downlink_mode." / ".$row->mode."</td>";
+					echo "<td>".$row->mode_rx." / ".$row->mode."</td>";
 				}
 
 				$phpdate = strtotime($row->timestamp);
@@ -94,7 +94,7 @@
 
 				$frequency = $row->frequency;
 
-				$frequency_rx = $row->downlink_freq;
+				$frequency_rx = $row->frequency_rx;
 
 				$power = $row->power;
 
@@ -119,7 +119,7 @@
 
 					// Get Satellite Mode
 					$uplink_mode = $this->get_mode_designator($row->frequency);
-					$downlink_mode = $this->get_mode_designator($row->downlink_freq);
+					$downlink_mode = $this->get_mode_designator($row->frequency_rx);
 
 					if (empty($uplink_mode)) {
 						$sat_mode = "";

--- a/application/migrations/100_rename_cat_columns.php
+++ b/application/migrations/100_rename_cat_columns.php
@@ -1,0 +1,75 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_rename_cat_columns extends CI_Migration {
+    public function up()
+    {
+        if ($this->db->field_exists('downlink_freq', 'cat')) {
+            $fields = array(
+               'downlink_freq' => array(
+                  'name' => 'frequency_rx',
+                  'type' => 'BIGINT',
+               ),
+            );
+            $this->dbforge->modify_column('cat', $fields);
+        }
+        if ($this->db->field_exists('downlink_mode', 'cat')) {
+            $fields = array(
+               'downlink_mode' => array(
+                  'name' => 'mode_rx',
+                  'type' => 'VARCHAR(255)',
+               ),
+            );
+            $this->dbforge->modify_column('cat', $fields);
+        }
+        if ($this->db->field_exists('uplink_freq', 'cat')) {
+            $this->dbforge->drop_column('cat', 'uplink_freq');
+        }
+        if ($this->db->field_exists('uplink_mode', 'cat')) {
+            $this->dbforge->drop_column('cat', 'uplink_mode');
+        }
+    }
+
+    public function down()
+    {
+        if ($this->db->field_exists('frequency_rx', 'cat')) {
+            $fields = array(
+               'frequency_rx' => array(
+                  'name' => 'downlink_freq',
+                  'type' => 'BIGINT',
+               ),
+            );
+            $this->dbforge->modify_column('cat', $fields);
+        }
+        if ($this->db->field_exists('mode_rx', 'cat')) {
+            $fields = array(
+               'mode_rx' => array(
+                  'name' => 'downlink_mode',
+                  'type' => 'VARCHAR(255)',
+               ),
+            );
+            $this->dbforge->modify_column('cat', $fields);
+        }
+        if (!$this->db->field_exists('uplink_freq', 'cat')) {
+            $fields = array(
+               'uplink_freq' => array(
+                  'type' => 'BIGINT',
+                  'null'    => TRUE,
+                  'default' => NULL,
+               ),
+            );
+            $this->dbforge->add_column('cat', $fields);
+        }
+        if (!$this->db->field_exists('uplink_mode', 'cat')) {
+            $fields = array(
+               'uplink_mode' => array(
+                  'type' => 'VARCHAR(255)',
+                  'null'    => TRUE,
+                  'default' => NULL,
+               ),
+            );
+            $this->dbforge->add_column('cat', $fields);
+        }
+    }
+}

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -39,18 +39,18 @@
 				$data['mode'] = $result['uplink_mode'];
 			}
 			if (isset($result['frequency_rx'])) {
-				$data['downlink_freq'] = $result['frequency_rx'];
+				$data['frequency_rx'] = $result['frequency_rx'];
 			} else if (isset($result['downlink_freq'])) {
-				$data['downlink_freq'] = $result['downlink_freq'];
+				$data['frequency_rx'] = $result['downlink_freq'];
 			} else {
-				$data['downlink_freq'] = NULL;
+				$data['frequency_rx'] = NULL;
 			}
 			if (isset($result['mode_rx'])) {
-				$data['downlink_mode'] = $result['mode_rx'];
+				$data['mode_rx'] = $result['mode_rx'];
 			} else if (isset($result['downlink_freq'])) {
-				$data['downlink_mode'] = $result['downlink_mode'];
+				$data['mode_rx'] = $result['downlink_mode'];
 			} else {
-				$data['downlink_mode'] = NULL;
+				$data['mode_rx'] = NULL;
 			}
 
 			if ($query->num_rows() > 0)

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -43,7 +43,7 @@
 			} else if (isset($result['downlink_freq'])) {
 				$data['downlink_freq'] = $result['downlink_freq'];
 			} else {
-				$data['downlink_freq'] = 0;
+				$data['downlink_freq'] = NULL;
 			}
 			if (isset($result['mode_rx'])) {
 				$data['downlink_mode'] = $result['mode_rx'];

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -28,14 +28,22 @@
 			// Let's keep uplink_freq, downlink_freq, uplink_mode and downlink_mode for backward compatibility
 			$data = array(
 				'prop_mode' => $prop_mode,
-				'frequency' => $result['frequency'] ?? $result['uplink_freq'],
 				'downlink_freq' => $result['frequency_rx'] ?? $result['downlink_freq'],
-				'mode' => $result['mode'] ?? $result['uplink_mode'],
 				'downlink_mode' => $result['mode_rx'] ?? $result['downlink_mode'],
 				'power' => $result['power'],
 				'sat_name' => $result['sat_name'],
 				'timestamp' => $timestamp,
 			);
+			if (isset($result['frequency']) && $result['frequency'] != "NULL") {
+				$data['frequency'] = $result['frequency'];
+			} else {
+				$data['frequency'] = $result['uplink_freq'];
+			}
+			if (isset($result['mode']) && $result['mode'] != "NULL") {
+				$data['mode'] = $result['mode'];
+			} else {
+				$data['mode'] = $result['uplink_mode'];
+			}
 
 			if ($query->num_rows() > 0)
 			{

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -4,11 +4,7 @@
 
 		function update($result, $user_id) {
 
-			if ($result['timestamp'] != "") {
-				$timestamp = gmdate("Y-m-d H:i:s");
-			} else {
-				$timestamp = gmdate("Y-m-d H:i:s");
-			}
+			$timestamp = gmdate("Y-m-d H:i:s");
 
 			if (isset($result['prop_mode'])) {
 				$prop_mode = $result['prop_mode'];

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -24,10 +24,8 @@
 			// Let's keep uplink_freq, downlink_freq, uplink_mode and downlink_mode for backward compatibility
 			$data = array(
 				'prop_mode' => $prop_mode,
-				'downlink_freq' => $result['frequency_rx'] ?? $result['downlink_freq'],
-				'downlink_mode' => $result['mode_rx'] ?? $result['downlink_mode'],
-				'power' => $result['power'],
-				'sat_name' => $result['sat_name'],
+				'power' => $result['power'] ?? 0,
+				'sat_name' => $result['sat_name'] ?? NULL,
 				'timestamp' => $timestamp,
 			);
 			if (isset($result['frequency']) && $result['frequency'] != "NULL") {
@@ -39,6 +37,20 @@
 				$data['mode'] = $result['mode'];
 			} else {
 				$data['mode'] = $result['uplink_mode'];
+			}
+			if (isset($result['frequency_rx'])) {
+				$data['downlink_freq'] = $result['frequency_rx'];
+			} else if (isset($result['downlink_freq'])) {
+				$data['downlink_freq'] = $result['downlink_freq'];
+			} else {
+				$data['downlink_freq'] = 0;
+			}
+			if (isset($result['mode_rx'])) {
+				$data['downlink_mode'] = $result['mode_rx'];
+			} else if (isset($result['downlink_freq'])) {
+				$data['downlink_mode'] = $result['downlink_mode'];
+			} else {
+				$data['downlink_mode'] = NULL;
 			}
 
 			if ($query->num_rows() > 0)


### PR DESCRIPTION
This drop cokumns with redundant data and renames the downlink stuff to `frequency_rx` and `mode_rx`. Made this a separate PR from https://github.com/kb-light/Cloudlog/pull/1 so that this can be viewed at separately. 